### PR TITLE
fix(macos): sign the app bundle so macOS releases open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         include:
           - os: windows-latest
           - os: ubuntu-latest
+          - os: macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,14 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            target: x86_64-pc-windows-msvc
+            rust_targets: x86_64-pc-windows-msvc
+            args: ''
           - os: macos-latest
-            target: aarch64-apple-darwin
+            rust_targets: aarch64-apple-darwin,x86_64-apple-darwin
+            args: '--target universal-apple-darwin'
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            rust_targets: x86_64-unknown-linux-gnu
+            args: ''
 
     runs-on: ${{ matrix.os }}
 
@@ -34,7 +37,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.rust_targets }}
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -76,6 +79,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
+          args: ${{ matrix.args }}
           tagName: ${{ github.ref_name }}
           releaseName: 'GodotHub ${{ github.ref_name }}'
           releaseBody: 'See the assets below for the installer and updater files for your platform.'

--- a/README.md
+++ b/README.md
@@ -259,6 +259,25 @@ GodotHub is available as a desktop application for:
 
 > [⬇️ Download the latest release](https://github.com/RykoTheDev/godothub/releases/latest)
 
+#### macOS: "GodotHub is damaged and can't be opened"
+
+GodotHub is code-signed, but it is **not notarized** — notarization requires a paid
+Apple Developer account. macOS therefore blocks the app the first time you open it.
+This is expected, and it takes one step to get past.
+
+Drag GodotHub to your Applications folder, then run:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/GodotHub.app
+```
+
+Prefer not to use the terminal? Open the app once and let macOS refuse, then go to
+**System Settings → Privacy & Security**, scroll down, and click **Open Anyway**.
+(On macOS 15 and newer, right-clicking → Open no longer bypasses this.)
+
+You only need to do this once per installed version. Updates applied through the
+app's built-in updater are not affected.
+
 ### Build from Source
 
 #### Prerequisites

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godothub",
-  "version": "1.1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godothub",
-      "version": "1.1",
+      "version": "1.1.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "godothub",
   "private": true,
-  "version": "1.1",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "godothub"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godothub"
-version = "1.1.0"
+version = "1.1.1"
 description = "Godot Version and Project Management"
 authors = ["Ryko"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GodotHub",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "identifier": "com.ryko.godothub",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -41,7 +41,11 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "createUpdaterArtifacts": true
+    "createUpdaterArtifacts": true,
+    "macOS": {
+      "signingIdentity": "-",
+      "minimumSystemVersion": "10.15"
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
Fixes #1.

The macOS `.app` bundle was never code-signed, so Gatekeeper treated the signature as invalid and said "is damaged", an error users can't click past. Setting an ad-hoc signing identity makes Tauri sign the bundle properly.

Tested on macOS (Apple Silicon): `codesign --verify --strict` passes and the app runs. It still isn't notarized (that needs the paid Apple account), so users get one "Apple could not verify..." prompt on first launch, but that one can be dismissed via System Settings > Privacy & Security > Open Anyway. Added a README section for it.

Also included:

- **Universal binary.** The release workflow declared `aarch64-apple-darwin` but never passed it to `tauri-action`, so it had no effect. v1.1 shipped arm64-only and wouldn't run on Intel Macs. This is the one change I couldn't test, since it needs a tag push.
- **macOS in CI.** There was no macOS runner, so nothing was compiled for it until release time.
- **Version bumped to 1.1.1.** `tauri.conf.json` was still on `1.0.0` while everything else was on `1.1`, and that file is what stamps the bundles, hence the `GodotHub_1.0.0_*` asset names on the v1.1 release. All in sync now, which may also sort out #3.