### PR TITLE
fix(macos): native titlebar, rounded corners, and Mac window lifecycle

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -197,9 +197,16 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
-                if window.label() == "main"
-                    && settings::read_settings(window.app_handle()).minimize_to_tray
-                {
+                if window.label() != "main" {
+                    return;
+                }
+
+                #[cfg(target_os = "macos")]
+                let keep_alive = true;
+                #[cfg(not(target_os = "macos"))]
+                let keep_alive = settings::read_settings(window.app_handle()).minimize_to_tray;
+
+                if keep_alive {
                     api.prevent_close();
                     let _ = window.hide();
                 }
@@ -299,6 +306,12 @@ pub fn run() {
             refresh_tray_menu,
             pick_folder,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app, _event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                show_main_window(_app);
+            }
+        });
 }

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -371,7 +371,12 @@ pub fn open_project(app: AppHandle, id: String, editor: bool) -> Result<(), Stri
 
     let settings = crate::settings::read_settings(&app);
     if settings.close_on_project_open {
-        if settings.minimize_to_tray {
+        #[cfg(target_os = "macos")]
+        let keep_alive = true;
+        #[cfg(not(target_os = "macos"))]
+        let keep_alive = settings.minimize_to_tray;
+
+        if keep_alive {
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.hide();
             }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "GodotHub",
+        "width": 1280,
+        "height": 720,
+        "resizable": true,
+        "fullscreen": false,
+        "maximized": false,
+        "decorations": true,
+        "transparent": false,
+        "alwaysOnTop": false,
+        "dragDropEnabled": true,
+        "minWidth": 1280,
+        "minHeight": 720,
+        "center": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 20,
+          "y": 22
+        }
+      }
+    ]
+  }
+}

--- a/src/components/Titlebar.tsx
+++ b/src/components/Titlebar.tsx
@@ -7,6 +7,7 @@ import { motion } from 'framer-motion'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { version } from '../../package.json'
 import { IconStar, IconHeart } from './Icons'
+import { isMac } from '../lib/platform'
 import { TaskTray } from './TaskTray'
 import { Tooltip } from './ui/Tooltip'
 
@@ -48,13 +49,11 @@ export function TitleBar() {
     <div className="relative h-10 flex items-stretch bg-surface border-line border-b select-none shrink-0">
       <div
         data-tauri-drag-region
-        onDoubleClick={() => safe((w) => w.toggleMaximize())}
         className="flex-1 flex items-center px-4 min-w-0"
       ></div>
 
       <div
         data-tauri-drag-region
-        onDoubleClick={() => safe((w) => w.toggleMaximize())}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-auto select-none"
@@ -85,7 +84,7 @@ export function TitleBar() {
         </motion.p>
       </div>
 
-      <div className="flex items-stretch gap-1">
+      <div className={`flex items-stretch gap-1 ${isMac ? 'pr-3' : ''}`}>
         <div className="flex items-center gap-1 pl-3 pr-5">
           <Tooltip content="Star on GitHub" side="bottom">
             <motion.button
@@ -112,59 +111,63 @@ export function TitleBar() {
         </div>
         <div className="w-px h-5 self-center bg-line/40" />
         <TaskTray />
-        <div className="w-px h-5 self-center bg-line/40" />
-        <div className="flex items-stretch gap-1 px-3">
-          <motion.button
-            onClick={() => safe((w) => w.minimize())}
-            aria-label="Minimize"
-            className="w-6 cursor-pointer flex items-center justify-center text-muted hover:text-ink transition-colors shrink-0"
-            whileHover={{
-              y: -2,
-              scale: 1.1,
-            }}
-            transition={{
-              type: 'spring',
-              stiffness: 500,
-              damping: 30,
-            }}
-          >
-            <div className="w-4 h-4 bg-green-400 rounded-full" />
-          </motion.button>
+        {!isMac && (
+          <>
+            <div className="w-px h-5 self-center bg-line/40" />
+            <div className="flex items-stretch gap-1 px-3">
+              <motion.button
+                onClick={() => safe((w) => w.minimize())}
+                aria-label="Minimize"
+                className="w-6 cursor-pointer flex items-center justify-center text-muted hover:text-ink transition-colors shrink-0"
+                whileHover={{
+                  y: -2,
+                  scale: 1.1,
+                }}
+                transition={{
+                  type: 'spring',
+                  stiffness: 500,
+                  damping: 30,
+                }}
+              >
+                <div className="w-4 h-4 bg-green-400 rounded-full" />
+              </motion.button>
 
-          <motion.button
-            onClick={() => safe((w) => w.toggleMaximize())}
-            aria-label={isMaximized ? 'Restore' : 'Maximize'}
-            className="w-6 cursor-pointer flex items-center justify-center text-muted hover:text-ink transition-colors shrink-0"
-            whileHover={{
-              y: -2,
-              scale: 1.1,
-            }}
-            transition={{
-              type: 'spring',
-              stiffness: 500,
-              damping: 30,
-            }}
-          >
-            <div className="w-4 h-4 bg-amber rounded-full" />
-          </motion.button>
+              <motion.button
+                onClick={() => safe((w) => w.toggleMaximize())}
+                aria-label={isMaximized ? 'Restore' : 'Maximize'}
+                className="w-6 cursor-pointer flex items-center justify-center text-muted hover:text-ink transition-colors shrink-0"
+                whileHover={{
+                  y: -2,
+                  scale: 1.1,
+                }}
+                transition={{
+                  type: 'spring',
+                  stiffness: 500,
+                  damping: 30,
+                }}
+              >
+                <div className="w-4 h-4 bg-amber rounded-full" />
+              </motion.button>
 
-          <motion.button
-            onClick={() => safe((w) => w.close())}
-            aria-label="Close"
-            className="w-6 cursor-pointer flex items-center justify-center text-muted hover:text-white transition-colors shrink-0"
-            whileHover={{
-              y: -2,
-              scale: 1.1,
-            }}
-            transition={{
-              type: 'spring',
-              stiffness: 500,
-              damping: 30,
-            }}
-          >
-            <div className="w-4 h-4 bg-red-400 rounded-full" />
-          </motion.button>
-        </div>
+              <motion.button
+                onClick={() => safe((w) => w.close())}
+                aria-label="Close"
+                className="w-6 cursor-pointer flex items-center justify-center text-muted hover:text-white transition-colors shrink-0"
+                whileHover={{
+                  y: -2,
+                  scale: 1.1,
+                }}
+                transition={{
+                  type: 'spring',
+                  stiffness: 500,
+                  damping: 30,
+                }}
+              >
+                <div className="w-4 h-4 bg-red-400 rounded-full" />
+              </motion.button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -19,6 +19,7 @@ import {
 } from '../Icons'
 import { getWorkspaceIcon } from '../../lib/workspaceIcons'
 import { formatLastOpened } from '../../lib/lastOpened'
+import { isMac } from '../../lib/platform'
 import type { Project, InstalledGodotVersion, Workspace } from '../../types'
 
 interface CommandItem {
@@ -204,7 +205,8 @@ export interface SettingSearchEntry {
   tab: string
 }
 
-export const SETTINGS_SEARCH_ITEMS: SettingSearchEntry[] = [
+export const SETTINGS_SEARCH_ITEMS: SettingSearchEntry[] = (
+  [
   { key: 'project_scan_dirs', label: 'Project scan folders', tab: 'storage' },
   { key: 'version_scan_dirs', label: 'Version scan folders', tab: 'storage' },
   { key: 'default_project_location', label: 'Default project location', tab: 'storage' },
@@ -238,7 +240,8 @@ export const SETTINGS_SEARCH_ITEMS: SettingSearchEntry[] = [
   { key: 'export_settings', label: 'Export settings to JSON', tab: 'advanced' },
   { key: 'import_settings', label: 'Import settings from JSON', tab: 'advanced' },
   { key: 'check_updates', label: 'Check for updates', tab: 'advanced' },
-]
+  ] as SettingSearchEntry[]
+).filter((item) => !(isMac && item.key === 'minimize_to_tray'))
 
 interface Props {
   onClose: () => void

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,1 @@
+export const isMac = /Mac/i.test(navigator.userAgent)

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from '../components/modals/ConfirmDialog'
 import { IconSun, IconMoon, IconHeart, IconRocket, IconBug } from '../components/Icons'
 import { api } from '../lib/api'
 import { applyTheme } from '../lib/colors'
+import { isMac } from '../lib/platform'
 import {
   applyRadius,
   applyDensity,
@@ -901,8 +902,9 @@ export function SettingsView({
                       Close application on project open
                     </span>
                     <p className="text-[11px] text-muted mt-1 leading-relaxed">
-                      Quits GodotHub automatically as soon as a project is
-                      launched in Godot.
+                      {isMac
+                        ? 'Hides GodotHub automatically as soon as a project is launched in Godot. It keeps running in the Dock.'
+                        : 'Quits GodotHub automatically as soon as a project is launched in Godot.'}
                     </p>
                   </div>
                   <Toggle
@@ -914,29 +916,31 @@ export function SettingsView({
                   />
                 </label>
 
-                <label className="flex items-center justify-between gap-4 pt-5 border-t border-line">
-                  <div>
-                    <span className="text-xs font-medium text-muted block">
-                      Minimize to system tray on closing app
-                    </span>
-                    <p className="text-[11px] text-muted mt-1 leading-relaxed">
-                      Keeps GodotHub running in the system tray instead of
-                      quitting when you close the window. Use the tray icon to
-                      reopen or quit.
-                    </p>
-                  </div>
-                  <Toggle
-                    checked={current.minimize_to_tray}
-                    onChange={(checked) =>
-                      setField('minimize_to_tray', checked)
-                    }
-                    label="Minimize to system tray on closing app"
-                  />
-                </label>
+                {!isMac && (
+                  <label className="flex items-center justify-between gap-4 pt-5 border-t border-line">
+                    <div>
+                      <span className="text-xs font-medium text-muted block">
+                        Minimize to system tray on closing app
+                      </span>
+                      <p className="text-[11px] text-muted mt-1 leading-relaxed">
+                        Keeps GodotHub running in the system tray instead of
+                        quitting when you close the window. Use the tray icon to
+                        reopen or quit.
+                      </p>
+                    </div>
+                    <Toggle
+                      checked={current.minimize_to_tray}
+                      onChange={(checked) =>
+                        setField('minimize_to_tray', checked)
+                      }
+                      label="Minimize to system tray on closing app"
+                    />
+                  </label>
+                )}
 
                 <AnimatePresence initial={false}>
                   {current.close_on_project_open &&
-                    current.minimize_to_tray && (
+                    (isMac || current.minimize_to_tray) && (
                       <motion.label
                         initial={{ height: 0, opacity: 0 }}
                         animate={{ height: 'auto', opacity: 1 }}
@@ -949,9 +953,9 @@ export function SettingsView({
                             Reopen after closing Godot
                           </span>
                           <p className="text-[11px] text-muted mt-1 leading-relaxed">
-                            Brings GodotHub back out of the system tray
-                            automatically once the Godot editor for that project
-                            is closed.
+                            {isMac
+                              ? 'Brings GodotHub back automatically once the Godot editor for that project is closed.'
+                              : 'Brings GodotHub back out of the system tray automatically once the Godot editor for that project is closed.'}
                           </p>
                         </div>
                         <Toggle


### PR DESCRIPTION
`decorations: false` was set for every platform to hide Windows' default
titlebar. On macOS that also killed the native traffic lights and the OS
corner rounding, and closing the window quit the app instead of keeping it
in the Dock.

* Add `tauri.macos.conf.json` with `decorations: true` + `titleBarStyle:
  "Overlay"`, so macOS supplies real traffic lights and rounded corners while
  the webview still draws under the custom 40px bar.
* Hide the custom window dots on macOS.
* Closing now hides the window and the app stays in the Dock. Quit with Cmd+Q
  or the tray. Same rule applied to `close_on_project_open`.
* Hide the minimize to tray setting on macOS since it no longer applies.
* Remove the duplicate `onDoubleClick` handlers. Tauri's drag script already
  toggles maximize, so double click was toggling twice and snapping back.
  This one is a fix on all platforms.

Windows and Linux are unaffected: `tauri.conf.json` is untouched, and Tauri
only loads a platform config matching the build target. Everything else is
behind `isMac` or `#[cfg(target_os = "macos")]`.

Note: `tauri.macos.conf.json` restates the whole window block because Tauri
merges platform configs with RFC 7396, which replaces arrays wholesale. Mirror
any future `width`/`minWidth` changes there.