### PR TITLE
fix: remember window size and position between launches

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1616,6 +1616,7 @@ dependencies = [
  "tauri-plugin-prevent-default",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tokio",
  "uuid",
  "zip 8.6.0",
@@ -4395,6 +4396,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.6.1",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ feed-rs = "2"
 tauri-plugin-single-instance = "2.0.0"
 notify = "6"
 tauri-plugin-updater = "2.10.1"
+tauri-plugin-window-state = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,15 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_prevent_default::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::POSITION
+                        | tauri_plugin_window_state::StateFlags::MAXIMIZED,
+                )
+                .build(),
+        )
         .setup(|app| {
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
@@ -192,6 +201,8 @@ pub fn run() {
                 .build(app)?;
 
             app.state::<TrayState>().0.lock().unwrap().replace(tray);
+
+            show_main_window(app.handle());
 
             Ok(())
         })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,9 +22,10 @@
         "transparent": false,
         "alwaysOnTop": false,
         "dragDropEnabled": true,
-        "minWidth": 1280,
-        "minHeight": 720,
-        "center": true
+        "minWidth": 1000,
+        "minHeight": 640,
+        "center": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -13,9 +13,10 @@
         "transparent": false,
         "alwaysOnTop": false,
         "dragDropEnabled": true,
-        "minWidth": 1280,
-        "minHeight": 720,
+        "minWidth": 1000,
+        "minHeight": 640,
         "center": true,
+        "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "trafficLightPosition": {


### PR DESCRIPTION
Fixes RykoTheDev/GodotHub#16

The app never saved window geometry, so every launch opened at a fixed
1280x720 centered — on all platforms, not just macOS.

- Adds `tauri-plugin-window-state` (size, position, maximized only)
- Lowers `minWidth`/`minHeight` to 1000x640; they matched the default
  size, so the window couldn't be shrunk at all
- Window starts hidden and shows once restored, avoiding a resize flash