### PR TITLE
fix(updater): stop updates failing on GitHub's anonymous rate limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,3 +131,59 @@ jobs:
             --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rewrite-updater-urls:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Point latest.json at the release download URLs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          release_id=$(gh api --paginate "repos/$REPO/releases" \
+            --jq "map(select(.tag_name == \"$TAG\")) | .[0].id // empty")
+          if [ -z "$release_id" ]; then
+            echo "no release found for tag $TAG" >&2
+            exit 1
+          fi
+          gh api --paginate "repos/$REPO/releases/$release_id/assets" > assets.json
+          asset_id=$(node -e "
+            const a = require('./assets.json').find((a) => a.name === 'latest.json');
+            if (!a) { console.error('latest.json is not attached to the release'); process.exit(1); }
+            console.log(a.id);
+          ")
+          gh api -H "Accept: application/octet-stream" \
+            "repos/$REPO/releases/assets/$asset_id" > latest.json
+          node - <<'EOF'
+          const fs = require('fs');
+          const manifest = JSON.parse(fs.readFileSync('latest.json', 'utf8'));
+          const downloadUrls = new Map(
+            JSON.parse(fs.readFileSync('assets.json', 'utf8')).map((a) => [
+              a.url,
+              a.browser_download_url,
+            ]),
+          );
+          let rewritten = 0;
+          let alreadyDirect = 0;
+          for (const [platform, data] of Object.entries(manifest.platforms ?? {})) {
+            if (!data.url.startsWith('https://api.github.com/')) {
+              alreadyDirect++;
+              continue;
+            }
+            const downloadUrl = downloadUrls.get(data.url);
+            if (!downloadUrl) {
+              throw new Error(`no release asset matches ${platform} url ${data.url}`);
+            }
+            data.url = downloadUrl;
+            rewritten++;
+          }
+          if (rewritten + alreadyDirect === 0) {
+            throw new Error('latest.json has no platform entries');
+          }
+          fs.writeFileSync('latest.json', JSON.stringify(manifest, null, 2));
+          console.log(`rewrote ${rewritten} urls, ${alreadyDirect} already direct`);
+          EOF
+          gh release upload "$TAG" latest.json --repo "$REPO" --clobber

--- a/src/components/modals/CheckForUpdatesModal.tsx
+++ b/src/components/modals/CheckForUpdatesModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { check } from '@tauri-apps/plugin-updater'
 import { getVersion } from '@tauri-apps/api/app'
 import { IconRefresh, IconDownload, IconCheck, IconX } from '../Icons'
+import { useSettings } from '../../hooks/useSettings'
 
 type UpdateState =
   | { type: 'checking' }
@@ -18,12 +19,43 @@ interface Props {
   mode?: 'background' | 'manual'
 }
 
+type TokenHint = 'rate-limited' | 'token-rejected'
+
+function githubTokenHint(message: string, hasToken: boolean): TokenHint | null {
+  if (/\b401\b/.test(message)) return 'token-rejected'
+  if (/\b403\b/.test(message) || /rate limit/i.test(message)) {
+    return hasToken ? 'token-rejected' : 'rate-limited'
+  }
+  return null
+}
+
+function downloadsFromGithubApi(rawJson: Record<string, unknown> | undefined) {
+  const platforms = rawJson?.platforms as
+    | Record<string, { url?: unknown }>
+    | undefined
+  if (!platforms) return false
+  const urls = Object.values(platforms)
+    .map((p) => p?.url)
+    .filter((u): u is string => typeof u === 'string')
+  if (urls.length === 0) return false
+  return urls.every((u) => {
+    try {
+      return new URL(u).host === 'api.github.com'
+    } catch {
+      return false
+    }
+  })
+}
+
 export function CheckForUpdatesModal({ onClose, mode = 'manual' }: Props) {
   const { t } = useTranslation('common')
+  const { settings } = useSettings()
   const [state, setState] = useState<UpdateState>({ type: 'checking' })
   const [currentVersion, setCurrentVersion] = useState<string | null>(null)
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
+
+  const githubToken = settings.github_token?.trim() || null
 
   const doCheck = useCallback(async () => {
     setState({ type: 'checking' })
@@ -36,19 +68,32 @@ export function CheckForUpdatesModal({ onClose, mode = 'manual' }: Props) {
           notes: update.body ?? null,
           downloadAndInstall: async () => {
             setState({ type: 'downloading', progress: 0 })
+            let downloaded = 0
+            let total: number | null = null
             try {
-              await update.downloadAndInstall((progressEvent) => {
-                const ev = progressEvent as Record<string, unknown>
-                if (ev && typeof ev === 'object' && 'event' in ev && (ev.event === 'Progress' || ev.event === 'DownloadProgress')) {
-                  const data = ev.data as Record<string, unknown> | undefined
-                  if (data && typeof data === 'object' && 'progress' in data) {
-                    const p = (data as Record<string, number>).progress
-                    if (typeof p === 'number') {
-                      setState({ type: 'downloading', progress: p })
+              const sendToken =
+                githubToken && downloadsFromGithubApi(update.rawJson)
+              await update.downloadAndInstall(
+                (progressEvent) => {
+                  if (progressEvent.event === 'Started') {
+                    downloaded = 0
+                    total = progressEvent.data.contentLength ?? null
+                  } else if (progressEvent.event === 'Progress') {
+                    downloaded += progressEvent.data.chunkLength
+                    if (total) {
+                      setState({
+                        type: 'downloading',
+                        progress: Math.min(downloaded / total, 1),
+                      })
                     }
+                  } else if (progressEvent.event === 'Finished') {
+                    setState({ type: 'downloading', progress: 1 })
                   }
-                }
-              })
+                },
+                sendToken
+                  ? { headers: { Authorization: `Bearer ${githubToken}` } }
+                  : undefined,
+              )
               setState({ type: 'done' })
             } catch (e) {
               setState({ type: 'error', message: String(e) })
@@ -68,7 +113,7 @@ export function CheckForUpdatesModal({ onClose, mode = 'manual' }: Props) {
       }
       setState({ type: 'error', message: String(e) })
     }
-  }, [mode])
+  }, [mode, githubToken])
 
   useEffect(() => {
     getVersion().then(setCurrentVersion).catch(() => setCurrentVersion(null))
@@ -82,6 +127,13 @@ export function CheckForUpdatesModal({ onClose, mode = 'manual' }: Props) {
     if (state.type === 'available') {
       await state.downloadAndInstall()
     }
+  }
+
+  const openTokenSettings = () => {
+    onClose()
+    window.dispatchEvent(
+      new CustomEvent('app:open-setting', { detail: 'github_token' }),
+    )
   }
 
   return (
@@ -215,17 +267,44 @@ export function CheckForUpdatesModal({ onClose, mode = 'manual' }: Props) {
             </div>
           )}
 
-          {state.type === 'error' && (
-            <div className="flex flex-col items-center gap-4">
+          {state.type === 'error' && (() => {
+            const hint = githubTokenHint(state.message, !!githubToken)
+            return (
+            <div className="flex flex-col items-center gap-4 w-full">
               <div className="w-14 h-14 rounded-full bg-danger/10 flex items-center justify-center">
                 <IconX className="w-6 h-6 text-danger" />
               </div>
               <div className="text-center">
-                <p className="text-sm font-medium text-ink">{t('check_updates_failed')}</p>
+                <p className="text-sm font-medium text-ink">
+                  {hint === 'rate-limited'
+                    ? t('check_updates_rate_limited')
+                    : hint === 'token-rejected'
+                      ? t('check_updates_token_rejected')
+                      : t('check_updates_failed')}
+                </p>
                 <p className="text-xs text-muted mt-1 max-w-xs">
                   {state.message}
                 </p>
               </div>
+              {hint && (
+                <div className="w-full bg-raised rounded-xl border border-line p-4 flex flex-col gap-3">
+                  <p className="text-[11px] text-muted leading-relaxed">
+                    {hint === 'token-rejected'
+                      ? t('check_updates_rate_limited_token_hint')
+                      : t('check_updates_rate_limited_hint')}
+                  </p>
+                  <motion.button
+                    whileHover={{ y: -1 }}
+                    whileTap={{ scale: 0.96 }}
+                    onClick={openTokenSettings}
+                    className="focus-ring cursor-pointer self-start px-4 py-2 rounded-lg bg-accent hover:bg-accent-bright text-xs font-medium text-white transition-colors"
+                  >
+                    {hint === 'token-rejected'
+                      ? t('check_updates_open_token_settings')
+                      : t('check_updates_add_token')}
+                  </motion.button>
+                </div>
+              )}
               <motion.button
                 whileHover={{ y: -1 }}
                 whileTap={{ scale: 0.96 }}
@@ -236,7 +315,8 @@ export function CheckForUpdatesModal({ onClose, mode = 'manual' }: Props) {
                 {t('check_updates_try_again')}
               </motion.button>
             </div>
-          )}
+            )
+          })()}
         </div>
 
         <div className="flex justify-end pt-3 border-t border-line">

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -529,6 +529,12 @@
   "check_updates_failed": "Update check failed",
   "check_updates_try_again": "Try Again",
   "check_updates_close_btn": "Close",
+  "check_updates_rate_limited": "GitHub rate limit reached",
+  "check_updates_token_rejected": "GitHub token rejected",
+  "check_updates_rate_limited_hint": "GitHub only allows 60 anonymous requests per hour, shared with everyone on your network. Adding a personal access token in Settings raises this to 5,000 per hour and is also used for fetching Godot versions.",
+  "check_updates_rate_limited_token_hint": "Your saved GitHub token was rejected. It may have expired or been revoked. Test it in Settings and replace it if needed.",
+  "check_updates_add_token": "Add GitHub Token",
+  "check_updates_open_token_settings": "Open Token Settings",
   
   "clone_repo_title": "Clone Repository",
   "clone_repo_desc": "Clone a Git repository and import it as a Godot project. The folder must contain a project.godot file.",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -529,6 +529,12 @@
   "check_updates_failed": "检查更新失败",
   "check_updates_try_again": "重试",
   "check_updates_close_btn": "关闭",
+  "check_updates_rate_limited": "已达到 GitHub 速率限制",
+  "check_updates_token_rejected": "GitHub 令牌被拒绝",
+  "check_updates_rate_limited_hint": "GitHub 每小时仅允许 60 次匿名请求，并且与同一网络下的所有人共享。在设置中添加个人访问令牌可将上限提高到每小时 5000 次，该令牌同样用于获取 Godot 版本列表。",
+  "check_updates_rate_limited_token_hint": "已保存的 GitHub 令牌被拒绝，可能已过期或被吊销。请在设置中测试该令牌，必要时请更换。",
+  "check_updates_add_token": "添加 GitHub 令牌",
+  "check_updates_open_token_settings": "打开令牌设置",
 
   "clone_repo_title": "克隆仓库",
   "clone_repo_desc": "克隆 Git 仓库并将其导入为 Godot 项目。文件夹必须包含 project.godot 文件。",

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -426,6 +426,7 @@ export function SettingsView({
       directory_naming_convention: { tab: 'behavior', section: 'behavior-projects' },
       git_init_new_projects: { tab: 'behavior', section: 'behavior-projects' },
       check_updates: { tab: 'advanced', section: 'advanced-updates' },
+      github_token: { tab: 'advanced', section: 'advanced-github-token' },
       tooltip_delay: { tab: 'behavior', section: 'behavior-projects' },
       tray_recent_projects_count: { tab: 'behavior', section: 'behavior' },
       command_palette_keybind: { tab: 'behavior', section: 'behavior' },
@@ -1736,6 +1737,7 @@ export function SettingsView({
             transition={{ duration: 0.12 }}
             className="flex flex-col gap-6"
           >
+            <div data-section-id="advanced-github-token">
             <SectionCard
               title={t('github_token_title')}
               description={t('github_token_desc')}
@@ -1803,6 +1805,7 @@ export function SettingsView({
                 </p>
               </div>
             </SectionCard>
+            </div>
 
             <div data-section-id="advanced-support" className="rounded-xl border border-line bg-surface/60 p-6 flex items-center justify-between gap-6">
               <div className="min-w-0">


### PR DESCRIPTION
## Problem

v1.2.0 users are told v1.2.1 is available, but installing it fails.

`latest.json` points every platform at `api.github.com` asset URLs, which
allow only 60 requests per hour **per IP**, shared across everyone behind
that address. On a busy or NAT'd connection the download gets a 403.

The check still works because the manifest comes from the release CDN, which
has no cap. Only the payload download hits the API. That is why it looks like
the app just does nothing.

| Request | Result |
|---|---|
| `api.github.com/.../assets/500278029`, anonymous | `403` |
| same URL with a token | `206` |
| `releases/download/v1.2.1/...` | `206`, no auth needed |

## Fix

1. **CI**: new job after the build matrix rewrites `latest.json` URLs to the
   release download URLs. Same bytes, no rate limit, signatures unchanged.
2. **App**: sends the existing Settings token on the download, and on failure
   says what to do instead of showing a raw status code.
3. Fixes the progress bar, which read a field the plugin never emits.