### PR TITLE
Follow the UI language for dates and CJK fonts

### DIFF
--- a/src/components/ContributorPRsModal.tsx
+++ b/src/components/ContributorPRsModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { openUrl } from '@tauri-apps/plugin-opener'
+import { formatLocaleDate } from '../lib/locale'
 
 interface PR {
   number: number
@@ -41,7 +42,7 @@ function stateBadge(pr: PR) {
 }
 
 function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return formatLocaleDate(new Date(iso), {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/src/components/modals/TimeTrackerModal.tsx
+++ b/src/components/modals/TimeTrackerModal.tsx
@@ -4,6 +4,7 @@ import type { Project } from '../../types'
 import { api } from '../../lib/api'
 import { effectiveTotalMs } from '../../lib/projectSort'
 import { formatDuration } from '../../lib/duration'
+import { formatLocaleDate } from '../../lib/locale'
 import { ModalShell } from './ModalShell'
 
 import { IconStopwatch, IconClock, IconHistory } from '../../lib/icons'
@@ -36,7 +37,7 @@ function isSameLocalWeek(aMs: number, bMs: number): boolean {
 }
 
 function dayLabel(key: string): string {
-  return new Date(`${key}T00:00:00`).toLocaleDateString(undefined, {
+  return formatLocaleDate(new Date(`${key}T00:00:00`), {
     weekday: 'short',
   })
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -199,4 +199,14 @@ i18n
     },
   })
 
+// Chromium picks CJK font fallbacks and line-breaking rules from <html lang>,
+// which index.html hardcodes to "en". Left stale, Japanese text can be drawn
+// with Chinese glyph forms. src/index.css keys its CJK stacks off :lang().
+function syncDocumentLanguage(lng: string): void {
+  document.documentElement.lang = lng
+}
+
+i18n.on('languageChanged', syncDocumentLanguage)
+syncDocumentLanguage(i18n.resolvedLanguage || i18n.language || 'en-US')
+
 export default i18n

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,36 @@
   --spacing: 4.5px;
 }
 
+/*
+ * CJK fallbacks. Inter and Google Sans Code carry no CJK glyphs, so Japanese
+ * and Chinese text drops straight to the generic family. The stacks stay
+ * scoped per language on purpose: ja and zh share Han characters but draw
+ * them with different regional forms, so one merged stack would render one of
+ * the two with the wrong glyphs. This relies on <html lang> tracking the UI
+ * language, which src/i18n/index.ts keeps in sync.
+ */
+:root {
+  --font-cjk: sans-serif;
+  --font-cjk-mono: monospace;
+
+  --font-display: 'Inter Variable', var(--font-cjk);
+  --font-body: 'Inter Variable', var(--font-cjk);
+  --font-mono: 'Google Sans Code', var(--font-cjk-mono);
+}
+
+html:lang(ja) {
+  --font-cjk: 'Yu Gothic UI', 'Hiragino Sans', 'Noto Sans CJK JP',
+    'Noto Sans JP', 'Meiryo', sans-serif;
+  --font-cjk-mono: 'Noto Sans Mono CJK JP', 'MS Gothic', 'Osaka-Mono',
+    monospace;
+}
+
+html:lang(zh) {
+  --font-cjk: 'Microsoft YaHei', 'PingFang SC', 'Noto Sans CJK SC',
+    'Noto Sans SC', sans-serif;
+  --font-cjk-mono: 'Noto Sans Mono CJK SC', 'NSimSun', monospace;
+}
+
 @property --spacing {
   syntax: '<length>';
   inherits: true;
@@ -145,8 +175,8 @@ textarea::placeholder {
 }
 
 .new-ui {
-  --font-display: var(--app-font-display, 'Inter Variable');
-  --font-body: var(--app-font-body, 'Inter Variable');
+  --font-display: var(--app-font-display, 'Inter Variable'), var(--font-cjk);
+  --font-body: var(--app-font-body, 'Inter Variable'), var(--font-cjk);
 }
 
 .new-ui .new-ui-scroll-viewport::-webkit-scrollbar {
@@ -285,7 +315,7 @@ textarea::placeholder {
   list-style: decimal;
 }
 .markdown-body code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, var(--font-cjk-mono);
   font-size: 0.8em;
   background: var(--color-raised);
   border: 1px solid var(--color-line);

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -1,0 +1,46 @@
+import i18n from '../i18n'
+
+/**
+ * BCP 47 tag for the Intl APIs, taken from the UI language instead of the OS.
+ *
+ * Passing `undefined` to Intl makes it follow the system locale, so picking
+ * Japanese on an English Windows still rendered dates as "Aug 26, 2026".
+ *
+ * `resolvedLanguage` is preferred over `language` because the detector can
+ * hand i18next a tag we do not ship (e.g. "de-DE"), and only the resolved
+ * value reflects the fallback that is actually being rendered.
+ */
+export function uiLocale(): string {
+  return i18n.resolvedLanguage || i18n.language || 'en-US'
+}
+
+export function formatLocaleDate(
+  date: Date,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  return date.toLocaleDateString(uiLocale(), options)
+}
+
+export function formatLocaleTime(
+  date: Date,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  return date.toLocaleTimeString(uiLocale(), options)
+}
+
+export function formatLocaleDateTime(
+  date: Date,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  return date.toLocaleString(uiLocale(), options)
+}
+
+export function formatRelativeTime(
+  value: number,
+  unit: Intl.RelativeTimeFormatUnit,
+): string {
+  return new Intl.RelativeTimeFormat(uiLocale(), { numeric: 'auto' }).format(
+    value,
+    unit,
+  )
+}

--- a/src/views/ChangelogView.tsx
+++ b/src/views/ChangelogView.tsx
@@ -17,6 +17,7 @@ import {
   IconRocket,
   IconTrash,
 } from '../lib/icons'
+import { formatLocaleDate } from '../lib/locale'
 import type { ChangelogEntry, ChangelogNote } from '../types'
 
 const IS_DEV = import.meta.env.DEV
@@ -25,7 +26,7 @@ function formatDate(raw: string): string {
   if (!raw) return ''
   const d = new Date(raw)
   if (Number.isNaN(d.getTime())) return raw
-  return d.toLocaleDateString(undefined, {
+  return formatLocaleDate(d, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -19,6 +19,7 @@ import {
   type LastOpenedTimeFormat,
 } from '../lib/lastOpened'
 import { formatDuration } from '../lib/duration'
+import { formatLocaleDate } from '../lib/locale'
 import { AnimatedNumber } from '../components/reusables/AnimatedNumber'
 import { OverlayScrollArea } from '../components/reusables/OverlayScrollArea'
 import {
@@ -493,13 +494,13 @@ function activityLabel(
     return `${h12} ${suffix}`
   }
   if (range === 'yearly') {
-    return new Date(`${key}-01T00:00:00`).toLocaleDateString(undefined, {
+    return formatLocaleDate(new Date(`${key}-01T00:00:00`), {
       month: 'short',
     })
   }
   const d = new Date(`${key}T00:00:00`)
   return range === 'weekly'
-    ? d.toLocaleDateString(undefined, { weekday: 'short' })
+    ? formatLocaleDate(d, { weekday: 'short' })
     : String(d.getDate())
 }
 
@@ -582,7 +583,7 @@ function ActivityChart({
 }
 
 function weekdayName(weekday: number): string {
-  return new Date(2026, 0, 5 + weekday).toLocaleDateString(undefined, {
+  return formatLocaleDate(new Date(2026, 0, 5 + weekday), {
     weekday: 'long',
   })
 }

--- a/src/views/NewsView.tsx
+++ b/src/views/NewsView.tsx
@@ -14,13 +14,14 @@ import {
   IconRefresh,
   IconWifiOff,
 } from '../lib/icons'
+import { formatLocaleDate } from '../lib/locale'
 import type { NewsItem } from '../types'
 
 function formatDate(iso: string | null): string | null {
   if (!iso) return null
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return null
-  return d.toLocaleDateString(undefined, {
+  return formatLocaleDate(d, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -10,6 +10,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { Toggle } from '../components/ui/Toggle'
 import { Slider } from '../components/ui/Slider'
 import { viewTransition } from '../lib/motion'
+import { formatLocaleDateTime, formatLocaleTime } from '../lib/locale'
 import { useSettings } from '../hooks/useSettings'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { useProjectsContext } from '../hooks/projectsContext'
@@ -311,7 +312,7 @@ export function SettingsView({ connected = false }: { connected?: boolean }) {
         setSyncUrl(info.gist_url)
         if (info.pushed_at) {
           try {
-            setLastPushedAt(new Date(info.pushed_at).toLocaleString())
+            setLastPushedAt(formatLocaleDateTime(new Date(info.pushed_at)))
           } catch {}
         }
       }
@@ -333,7 +334,7 @@ export function SettingsView({ connected = false }: { connected?: boolean }) {
       try {
         const res = await api.gistSyncPush()
         setSyncUrl(res.gist_url)
-        setLastAutoBackup(new Date().toLocaleTimeString())
+        setLastAutoBackup(formatLocaleTime(new Date()))
       } catch (e) {
         console.error('[auto-backup] failed:', e)
       }
@@ -502,7 +503,7 @@ export function SettingsView({ connected = false }: { connected?: boolean }) {
     try {
       const res = await api.gistSyncPush()
       setSyncUrl(res.gist_url)
-      setLastPushedAt(new Date(res.pushed_at).toLocaleString())
+      setLastPushedAt(formatLocaleDateTime(new Date(res.pushed_at)))
       setSyncMessage(ts('sync_push_done'))
     } catch (e) {
       setSyncMessage(String(e))

--- a/src/views/TemplatesView.tsx
+++ b/src/views/TemplatesView.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { AnimatedNumber } from '../components/reusables/AnimatedNumber'
 import { api } from '../lib/api'
 import { consumePendingAction } from '../lib/pendingAction'
+import { formatLocaleDate } from '../lib/locale'
 import { useSettings } from '../hooks/useSettings'
 import { useWorkspaces } from '../hooks/useWorkspaces'
 import type { ProjectTemplate, TemplateSyncResult } from '../types'
@@ -384,7 +385,7 @@ export function TemplatesView({
                             <>
                               <span>·</span>
                               <span>
-                                {new Date(tmpl.created_at).toLocaleDateString()}
+                                {formatLocaleDate(new Date(tmpl.created_at))}
                               </span>
                             </>
                           )}

--- a/src/views/UpdatesView.tsx
+++ b/src/views/UpdatesView.tsx
@@ -9,6 +9,7 @@ import { ViewHeader } from '../components/reusables/ViewHeader'
 import { useSettings } from '../hooks/useSettings'
 import { useUpdates } from '../hooks/useUpdates'
 import { useUpdatesBadge } from '../hooks/useUpdatesBadge'
+import { formatLocaleDate, formatRelativeTime } from '../lib/locale'
 import type { UpdateEntry, UpdateKind } from '../types'
 import {
   IconAlertTriangle,
@@ -67,7 +68,7 @@ function formatDate(at: number): string {
   if (!at) return ''
   const d = new Date(at * 1000)
   if (Number.isNaN(d.getTime())) return ''
-  return d.toLocaleDateString(undefined, {
+  return formatLocaleDate(d, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
@@ -88,16 +89,10 @@ function formatTimeAgo(at: number): string {
   for (const [unit, secondsPer] of units) {
     const value = Math.floor(seconds / secondsPer)
     if (value >= 1) {
-      return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(
-        -value,
-        unit,
-      )
+      return formatRelativeTime(-value, unit)
     }
   }
-  return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(
-    -seconds,
-    'second',
-  )
+  return formatRelativeTime(-seconds, 'second')
 }
 
 function CardContent({


### PR DESCRIPTION
Three related gaps that make non-English locales render as English, or with the wrong glyphs. None of them are Japanese-specific — they affect every locale in `LANGUAGES` — but they got much more visible now that Japanese and French are at 100%.

## 1. Dates and relative times ignore the UI language

Every `Intl` call in the app passed `undefined` as the locale:

```ts
d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
```

`undefined` means "use the OS locale", not "use the app language". So on an English Windows, picking 日本語 in Settings still renders `Aug 26, 2026` in the Changelog and `2 days ago` in Updates. The language switch appeared to only half-apply.

Added `src/lib/locale.ts`, which reads i18next's `resolvedLanguage`, and routed the 13 call sites through it: `ChangelogView`, `NewsView`, `UpdatesView`, `DashboardView`, `TemplatesView`, `SettingsView`, `TimeTrackerModal`, `ContributorPRsModal`.

It reads `resolvedLanguage` rather than `language` because the detector can hand i18next a tag we don't ship (say `de-DE`), and only the resolved value reflects the fallback that's actually on screen.

`BugReportModal` is deliberately left alone. Its timestamps are payload for a GitHub issue, not UI chrome, so they shouldn't shift with the reporter's UI language.

## 2. `<html lang>` is hardcoded to `en`

This one looks cosmetic and isn't, so it's worth a short explanation.

Unicode's Han Unification assigned a single code point to kanji whose *correct printed shape* differs between Japanese, Simplified Chinese and Traditional Chinese. 刃, 直, 海, 角, 骨 and 入 are all drawn differently in a Japanese font than in a Chinese one. Chromium picks its CJK fallback font from the `lang` attribute, so with `lang="en"` frozen in `index.html`, it is free to render Japanese text with a Chinese font. The result isn't garbled — it's subtly wrong in a way that, as Kenji Iguchi puts it, looks "non-native, vaguely shady, and plain bizarre" to a native reader:

**https://heistak.github.io/your-code-displays-japanese-wrong/**

`lang` also drives line-breaking rules, which matter a lot more in a language written without spaces.

`src/i18n/index.ts` now sets `document.documentElement.lang` on init and on every `languageChanged`.

## 3. The font stacks have no CJK coverage

`--font-display` and `--font-body` were `'Inter Variable', sans-serif`. Inter ships no CJK glyphs, so every Japanese and Chinese character fell through to the generic `sans-serif` — i.e. to whatever the browser felt like picking, which is exactly the situation §2 describes.

`src/index.css` now defines `--font-cjk` / `--font-cjk-mono` and appends them to `--font-display`, `--font-body`, `--font-mono`, the `.new-ui` custom-font overrides, and `.markdown-body code`.

The stacks are scoped per language with `:lang()` instead of being merged into one list:

```css
html:lang(ja) {
  --font-cjk: 'Yu Gothic UI', 'Hiragino Sans', 'Noto Sans CJK JP',
    'Noto Sans JP', 'Meiryo', sans-serif;
}
html:lang(zh) {
  --font-cjk: 'Microsoft YaHei', 'PingFang SC', 'Noto Sans CJK SC',
    'Noto Sans SC', sans-serif;
}
```

A single merged stack can't work: whichever CJK font comes first wins for **both** languages, so one of ja/zh would always get the other's glyph forms. That's what makes §2 a prerequisite rather than a nicety — `:lang()` only matches if `<html lang>` is correct.

No new font is bundled; these are system fonts, with Noto CJK as the Linux fallback.

## Not in this PR

`<html dir>` is untouched. `ar-MA` is registered and ships Arabic strings, so it arguably wants `dir="rtl"` from the same hook — but the layout uses physical padding/margin utilities throughout, and flipping direction app-wide without an RTL audit would be a regression rather than a fix. That deserves its own PR.
