### PR TITLE
Fix overlap between news buttons

### DIFF
--- a/src/views/NewsView.tsx
+++ b/src/views/NewsView.tsx
@@ -219,7 +219,7 @@ export function NewsView({ connected = false }: { connected?: boolean }) {
               )}
             </>
           )}
-          <div className="shrink-0 h-4" aria-hidden="true" />
+          <div className="shrink-0 h-20" aria-hidden="true" />
         </div>
       </OverlayScrollArea>
     </div>


### PR DESCRIPTION
The "Scroll to top" button overlaps the "Show more" button at the bottom of the Godot News page.

This change increases the bottom spacing in the news scroll area so both buttons remain visible and accessible.