### PR TITLE
Add system language option and ordering

### DIFF
--- a/src/components/reusables/LanguageFlag.tsx
+++ b/src/components/reusables/LanguageFlag.tsx
@@ -1,4 +1,14 @@
-import { US, CN, RU, MA, MX, JP, FR , VN, BR} from 'country-flag-icons/react/3x2'
+import {
+  US,
+  CN,
+  RU,
+  MA,
+  MX,
+  JP,
+  FR,
+  VN,
+  BR,
+} from 'country-flag-icons/react/3x2'
 
 const FLAGS: Record<string, typeof US> = {
   US,
@@ -21,14 +31,31 @@ export function LanguageFlag({
   className?: string
   title?: string
 }) {
+  if (country === 'SYSTEM') {
+    return (
+      <span
+        aria-hidden="true"
+        className={`inline-flex shrink-0 items-center justify-center ${className}`}
+        title={title ?? 'System language'}
+      >
+        🌐
+      </span>
+    )
+  }
+
   const Flag = FLAGS[country]
+
   if (!Flag) return null
+
   return (
     <span
       aria-hidden="true"
       className={`inline-flex shrink-0 overflow-hidden rounded-[3px] ring-1 ring-black/10 ${className}`}
     >
-      <Flag className="w-full h-full" title={title ?? country} />
+      <Flag
+        className="w-full h-full"
+        title={title ?? country}
+      />
     </span>
   )
 }

--- a/src/components/titlebar/LanguageMenu.tsx
+++ b/src/components/titlebar/LanguageMenu.tsx
@@ -1,10 +1,18 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import i18n from '../../i18n'
 import {
   LANGUAGES,
+  SYSTEM_LANGUAGE,
+  getSystemLanguage,
   languageStatusLabelKey,
   type LanguageStatus,
 } from '../../i18n/languages'
@@ -35,24 +43,42 @@ export function LanguageMenu() {
       {ts(languageStatusLabelKey(status))}
     </span>
   )
+
   const [open, setOpen] = useState(false)
   const [dir, setDir] = useState(false)
-  const [pos, setPos] = useState<{ left: number; top: number } | null>(null)
+  const [pos, setPos] = useState<{
+    left: number
+    top: number
+  } | null>(null)
+
   const ref = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        if (listRef.current?.contains(e.target as Node)) return
+      if (
+        ref.current &&
+        !ref.current.contains(e.target as Node)
+      ) {
+        if (
+          listRef.current?.contains(e.target as Node)
+        ) {
+          return
+        }
+
         setOpen(false)
       }
     }
+
     const keyHandler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') {
+        setOpen(false)
+      }
     }
+
     document.addEventListener('mousedown', handler)
     document.addEventListener('keydown', keyHandler)
+
     return () => {
       document.removeEventListener('mousedown', handler)
       document.removeEventListener('keydown', keyHandler)
@@ -61,49 +87,114 @@ export function LanguageMenu() {
 
   const measure = useCallback(() => {
     const el = ref.current
-    if (!el || !listRef.current) return
+
+    if (!el || !listRef.current) {
+      return
+    }
+
     const r = el.getBoundingClientRect()
     const spaceBelow = window.innerHeight - r.bottom
     const d = spaceBelow < OPEN_UP_THRESHOLD
     const h = listRef.current.offsetHeight
+
     setDir(d)
+
     setPos({
-      left: Math.max(EDGE_PADDING, r.right - MENU_WIDTH),
-      top: Math.max(EDGE_PADDING, d ? r.top - h - GAP : r.bottom + GAP),
+      left: Math.max(
+        EDGE_PADDING,
+        r.right - MENU_WIDTH,
+      ),
+      top: Math.max(
+        EDGE_PADDING,
+        d
+          ? r.top - h - GAP
+          : r.bottom + GAP,
+      ),
     })
   }, [])
 
   useLayoutEffect(() => {
-    if (open) measure()
-  }, [open, measure])
-
-  useEffect(() => {
-    if (!open) return
-    const reposition = () => measure()
-    window.addEventListener('scroll', reposition, true)
-    window.addEventListener('resize', reposition)
-    return () => {
-      window.removeEventListener('scroll', reposition, true)
-      window.removeEventListener('resize', reposition)
+    if (open) {
+      measure()
     }
   }, [open, measure])
 
-  const isActive = (value: string) =>
-    i18n.language === value || i18n.language.startsWith(value.split('-')[0])
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const reposition = () => measure()
+
+    window.addEventListener(
+      'scroll',
+      reposition,
+      true,
+    )
+
+    window.addEventListener(
+      'resize',
+      reposition,
+    )
+
+    return () => {
+      window.removeEventListener(
+        'scroll',
+        reposition,
+        true,
+      )
+
+      window.removeEventListener(
+        'resize',
+        reposition,
+      )
+    }
+  }, [open, measure])
+
+  const isActive = (value: string) => {
+    if (value === SYSTEM_LANGUAGE) {
+      return settings.language === SYSTEM_LANGUAGE
+    }
+
+    if (settings.language === SYSTEM_LANGUAGE) {
+      return false
+    }
+
+    return (
+      i18n.language === value ||
+      i18n.language.startsWith(
+        value.split('-')[0],
+      )
+    )
+  }
 
   const select = (value: string) => {
-    i18n.changeLanguage(value)
-    update({ ...settings, language: value })
+    const language =
+      value === SYSTEM_LANGUAGE
+        ? getSystemLanguage()
+        : value
+
+    i18n.changeLanguage(language)
+
+    update({
+      ...settings,
+      language: value,
+    })
+
     setOpen(false)
   }
 
-  const noDrag = (e: React.MouseEvent) => e.stopPropagation()
+  const noDrag = (e: React.MouseEvent) =>
+    e.stopPropagation()
 
   return (
     <>
-      <div ref={ref} className="flex items-stretch shrink-0">
+      <div
+        ref={ref}
+        className="flex items-stretch shrink-0"
+      >
         <Tooltip content={ts('language_label')}>
-        <motion.button
+          <motion.button
             type="button"
             onClick={() => setOpen((o) => !o)}
             onMouseDown={noDrag}
@@ -112,7 +203,11 @@ export function LanguageMenu() {
             aria-haspopup="menu"
             whileHover={{ scale: 1.08 }}
             whileTap={{ scale: 0.9 }}
-            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+            transition={{
+              type: 'spring',
+              stiffness: 500,
+              damping: 30,
+            }}
             className="focus-ring cursor-pointer relative w-9 h-8 flex items-center justify-center rounded-item text-muted hover:text-ink hover:bg-raised transition-colors shrink-0"
           >
             <IconLanguage className="w-4 h-4" />
@@ -125,27 +220,54 @@ export function LanguageMenu() {
           {open && (
             <motion.div
               ref={listRef}
-              initial={{ opacity: 0, y: dir ? 6 : -6, scale: 0.96 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: dir ? 6 : -6, scale: 0.96 }}
-              transition={{ duration: 0.15, ease: 'easeOut' }}
+              initial={{
+                opacity: 0,
+                y: dir ? 6 : -6,
+                scale: 0.96,
+              }}
+              animate={{
+                opacity: 1,
+                y: 0,
+                scale: 1,
+              }}
+              exit={{
+                opacity: 0,
+                y: dir ? 6 : -6,
+                scale: 0.96,
+              }}
+              transition={{
+                duration: 0.15,
+                ease: 'easeOut',
+              }}
               role="menu"
               className={`fixed z-50 ${
-                dir ? 'origin-bottom' : 'origin-top'
+                dir
+                  ? 'origin-bottom'
+                  : 'origin-top'
               } rounded-menu border border-outline/50 bg-overlay shadow-md shadow-black/10 p-1.5`}
-              style={{ left: pos?.left, top: pos?.top, width: MENU_WIDTH }}
+              style={{
+                left: pos?.left,
+                top: pos?.top,
+                width: MENU_WIDTH,
+              }}
             >
               <div className="px-2.5 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted/50">
                 {ts('language_label')}
               </div>
+
               {LANGUAGES.map((lang) => {
                 const active = isActive(lang.value)
+                const isSystem =
+                  lang.value === SYSTEM_LANGUAGE
+
                 return (
                   <button
                     key={lang.value}
                     type="button"
                     role="menuitem"
-                    onClick={() => select(lang.value)}
+                    onClick={() =>
+                      select(lang.value)
+                    }
                     className={`focus-ring cursor-pointer w-full flex items-center justify-between gap-2 text-left px-2.5 py-2 rounded-item text-xs transition-colors ${
                       active
                         ? 'bg-accent/15 text-accent-bright'
@@ -153,11 +275,21 @@ export function LanguageMenu() {
                     }`}
                   >
                     <span className="flex items-center gap-1.5 min-w-0">
-                      <LanguageFlag country={lang.country} />
-                      <span className="truncate">{lang.label}</span>
-                      {badge(lang.status)}
+                      <LanguageFlag
+                        country={lang.country}
+                      />
+
+                      <span className="truncate">
+                      {lang.labelKey ? ts(lang.labelKey): lang.label}
+                      </span>
+
+                      {!isSystem &&
+                        badge(lang.status)}
                     </span>
-                    {active && <IconCheck className="w-3.5 h-3.5" />}
+
+                    {active && (
+                      <IconCheck className="w-3.5 h-3.5" />
+                    )}
                   </button>
                 )
               })}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -27,6 +27,10 @@ import {
   applyRadius,
   applyScrollbars,
 } from '../lib/appearance'
+import {
+  SYSTEM_LANGUAGE,
+  getSystemLanguage,
+} from '../i18n/languages'
 import { registerPendingSave } from '../lib/pendingSave'
 import { useWorkspaces } from './useWorkspaces'
 import { defaultCornerRadius } from '../lib/platform'
@@ -143,7 +147,11 @@ function applySettingsAppearance(prev: AppSettings, next: AppSettings) {
   }
   if (next.language && next.language !== prev.language) {
     localStorage.setItem('i18nextLng', next.language)
-    if (next.language !== i18n.language) i18n.changeLanguage(next.language)
+    const resolvedLanguage = next.language === SYSTEM_LANGUAGE ? getSystemLanguage() : next.language
+
+if (resolvedLanguage !== i18n.language) {
+  i18n.changeLanguage(resolvedLanguage)
+}
   }
 }
 
@@ -174,7 +182,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       )
       applyAppearance(s)
       if (s.language && s.language !== i18n.language) {
-        i18n.changeLanguage(s.language)
+        i18n.changeLanguage(
+          s.language === SYSTEM_LANGUAGE
+          ? getSystemLanguage()
+           : s.language,
+          )
       }
       setLoaded(true)
     })

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -1,20 +1,35 @@
 export type LanguageStatus = 'complete' | 'beta' | 'incomplete'
 
+export const SYSTEM_LANGUAGE = 'system'
+
 export interface LanguageOption {
   value: string
   label: string
+  labelKey?: string
   country: string
   status: LanguageStatus
+  priority?: number
 }
 
 export const LANGUAGES: LanguageOption[] = [
+  {
+    value: SYSTEM_LANGUAGE,
+    label: 'System language',
+    labelKey: 'language_system',
+    country: 'SYSTEM',
+    status: 'complete',
+    priority: -1,
+  },
+
   { value: 'en-US', label: 'English', country: 'US', status: 'complete' },
   { value: 'ja-JP', label: '日本語', country: 'JP', status: 'complete' },
   { value: 'fr-FR', label: 'Français', country: 'FR', status: 'complete' },
+
   { value: 'pt-BR', label: 'Português (Brasil)', country: 'BR', status: 'beta' },
   { value: 'zh-CN', label: '简体中文', country: 'CN', status: 'beta' },
   { value: 'ar-MA', label: 'العربية', country: 'MA', status: 'beta' },
   { value: 'vi-VN', label: 'Tiếng Việt', country: 'VN', status: 'beta' },
+
   { value: 'es-MX', label: 'Español', country: 'MX', status: 'incomplete' },
   { value: 'ru-RU', label: 'Русский', country: 'RU', status: 'incomplete' },
 ]
@@ -29,3 +44,85 @@ export function languageStatusLabelKey(status: LanguageStatus): string {
       return 'language_incomplete'
   }
 }
+
+export function getSystemLanguage(): string {
+  if (typeof navigator === 'undefined') {
+    return 'en-US'
+  }
+
+  const availableLanguages = LANGUAGES.filter(
+    (language) => language.value !== SYSTEM_LANGUAGE,
+  )
+
+  const systemLanguages =
+    navigator.languages?.length
+      ? navigator.languages
+      : [navigator.language]
+
+  for (const systemLanguage of systemLanguages) {
+    const normalized = systemLanguage.toLowerCase()
+
+    const exact = availableLanguages.find(
+      (language) =>
+        language.value.toLowerCase() === normalized,
+    )
+
+    if (exact) {
+      return exact.value
+    }
+
+    const baseLanguage = normalized.split('-')[0]
+
+    const compatible = availableLanguages.find(
+      (language) =>
+        language.value.toLowerCase().split('-')[0] === baseLanguage,
+    )
+
+    if (compatible) {
+      return compatible.value
+    }
+  }
+
+  return 'en-US'
+}
+
+const STATUS_ORDER: Record<LanguageStatus, number> = {
+  complete: 0,
+  beta: 1,
+  incomplete: 2,
+}
+
+const countryNames = new Intl.DisplayNames(['en'], {
+  type: 'region',
+})
+
+LANGUAGES.sort((a, b) => {
+  const priorityDifference =
+    (a.priority ?? 0) - (b.priority ?? 0)
+
+  if (priorityDifference !== 0) {
+    return priorityDifference
+  }
+
+  const statusDifference =
+    STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
+
+  if (statusDifference !== 0) {
+    return statusDifference
+  }
+
+  if (
+    a.value === SYSTEM_LANGUAGE ||
+    b.value === SYSTEM_LANGUAGE
+  ) {
+    return 0
+  }
+
+  const countryA =
+    countryNames.of(a.country) ?? a.country
+
+  const countryB =
+    countryNames.of(b.country) ?? b.country
+
+  return countryA.localeCompare(countryB, 'en')
+})

--- a/src/i18n/locales/ar-MA/settings.json
+++ b/src/i18n/locales/ar-MA/settings.json
@@ -270,6 +270,7 @@
   "token_help_desc": "أنشئ رمزًا مميزًا على github.com/settings/tokens. ما عليك سوى تحديد نطاق public_repo إذا كنت ترغب في الوصول إلى المستودع الخاص، وإلا فاترك جميع النطاقات غير محددة. لا توجد أذونات حساسة مطلوبة.",
   "search_placeholder": "ابحث في الإعدادات…",
   "language_label": "اللغة",
+  "language_system": "لغة النظام",
   "language_complete": "مكتملة",
   "language_beta": "تجريبية",
   "language_incomplete": "غير مكتملة",

--- a/src/i18n/locales/en-US/settings.json
+++ b/src/i18n/locales/en-US/settings.json
@@ -335,6 +335,7 @@
   "landing_tab_label": "Default landing page",
   "landing_tab_desc": "Which view opens when the app starts. The dashboard is only available in the new UI, so the classic interface falls back to Projects.",
   "language_label": "Language",
+  "language_system": "System language",
   "language_complete": "Complete",
   "language_beta": "Beta",
   "language_incomplete": "Incomplete",

--- a/src/i18n/locales/es-MX/settings.json
+++ b/src/i18n/locales/es-MX/settings.json
@@ -199,6 +199,7 @@
   "card_layout_label": "Card layout",
   "card_layout_desc": "Show the sidebar, views, and titlebar as separate floating rounded cards. Turn off for a connected layout where everything merges into one surface, like the classic UI.",
   "language_label": "Language",
+  "language_system": "Idioma del sistema",
   "language_complete": "Complete",
   "language_beta": "Beta",
   "language_incomplete": "Incomplete",

--- a/src/i18n/locales/fr-FR/settings.json
+++ b/src/i18n/locales/fr-FR/settings.json
@@ -344,6 +344,7 @@
   "landing_tab_label": "Page d'accueil par défaut",
   "landing_tab_desc": "Quelle vue s'ouvre au démarrage de l'application. Le tableau de bord n'est disponible que dans la nouvelle interface, l'interface classique se rabat donc sur Projets.",
   "language_label": "Langue",
+  "language_system": "Langue du système",
   "language_complete": "Complète",
   "language_beta": "Bêta",
   "language_incomplete": "Incomplète",

--- a/src/i18n/locales/ja-JP/settings.json
+++ b/src/i18n/locales/ja-JP/settings.json
@@ -333,6 +333,7 @@
   "landing_tab_label": "起動時に表示する画面",
   "landing_tab_desc": "アプリの起動時に開く画面です。ダッシュボードは新 UI でのみ利用できるため、クラシックインターフェースでは「プロジェクト」が代わりに開きます。",
   "language_label": "言語",
+  "language_system": "システム言語",
   "language_complete": "翻訳済み",
   "language_beta": "ベータ",
   "language_incomplete": "一部未翻訳",

--- a/src/i18n/locales/pt-BR/settings.json
+++ b/src/i18n/locales/pt-BR/settings.json
@@ -335,6 +335,7 @@
   "landing_tab_label": "Página inicial padrão",
   "landing_tab_desc": "Define qual visualização abre quando o aplicativo inicia. O Painel só está disponível na nova interface, então a interface clássica usa Projetos como alternativa.",
   "language_label": "Idioma",
+  "language_system": "Idioma do sistema",
   "language_complete": "Completo",
   "language_beta": "Beta",
   "language_incomplete": "Incompleto",

--- a/src/i18n/locales/ru-RU/settings.json
+++ b/src/i18n/locales/ru-RU/settings.json
@@ -163,6 +163,7 @@
   "token_help_desc": "Создайте токен на github.com/settings/tokens. You only need to check the public_repo scope if you want private repo access, otherwise leave all scopes unchecked. No sensitive permissions required.",
   "search_placeholder": "Найти настройки…",
   "language_label": "Язык",
+  "language_system": "Язык системы",
   "use_os_decorations": "Использовать системный вид окна",
   "use_os_decorations_desc": "Использует нативную (встроенную) строку заголовка операционной системы и элементы управления окна вместо пользовательских элементов управления GodotHub. Требуется перезапуск, чтобы изменения полностью вступили в силу.",
   "accessibility": "Accessibility",

--- a/src/i18n/locales/vi-VN/settings.json
+++ b/src/i18n/locales/vi-VN/settings.json
@@ -344,6 +344,7 @@
   "landing_tab_label": "Trang đích mặc định",
   "landing_tab_desc": "View nào mở khi ứng dụng khởi động. Dashboard chỉ có trong giao diện mới, nên giao diện cổ điển sẽ về Dự án.",
   "language_label": "Ngôn ngữ",
+  "language_system": "Ngôn ngữ hệ thống",
   "language_complete": "Hoàn chỉnh",
   "language_beta": "Beta",
   "language_incomplete": "Chưa hoàn chỉnh",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -197,6 +197,7 @@
   "search_placeholder": "搜索设置…",
   "interface_label": "界面",
   "language_label": "语言",
+  "language_system": "系统语言",
   "use_os_decorations": "使用系统窗口装饰",
   "use_os_decorations_desc": "使用操作系统的原生标题栏和窗口控件，而不是 GodotHub 的自定义标题栏。需要重启才能完全生效。",
   "accessibility": "辅助功能",

--- a/src/views/OnboardingView.tsx
+++ b/src/views/OnboardingView.tsx
@@ -11,7 +11,11 @@ import {
   resolveThemeMode,
   getThemePreset,
 } from '../lib/colors'
-import { LANGUAGES } from '../i18n/languages'
+import {
+  LANGUAGES,
+  SYSTEM_LANGUAGE,
+  getSystemLanguage,
+} from '../i18n/languages'
 import { defaultCornerRadius } from '../lib/platform'
 import {
   useOnboarding,
@@ -333,9 +337,7 @@ export function OnboardingView({
                               align="left"
                               trigger={({ open, toggle }) => {
                                 const current = LANGUAGES.find(
-                                  (l) =>
-                                    i18n.language === l.value ||
-                                    i18n.language.startsWith(l.value.split('-')[0]),
+                                  (l) => l.value === draft.language,
                                 )
                                 return (
                                   <button
@@ -345,20 +347,33 @@ export function OnboardingView({
                                     className="focus-ring cursor-pointer inline-flex items-center gap-2 px-3.5 py-2 rounded-btn border border-outline/50 bg-overlay text-sm font-medium text-ink hover:border-accent-dim transition-colors"
                                   >
                                     {current && <LanguageFlag country={current.country} />}
-                                    {current?.label ?? i18n.language}
+                                    {current
+                                      ? current.labelKey
+                                        ? i18n.t(`settings:${current.labelKey}`)
+                                        : current.label
+                                      : i18n.language}
                                     <IconChevronDown className={`w-3 h-3 text-muted transition-transform duration-200 ${open ? 'rotate-180' : ''}`} />
                                   </button>
                                 )
                               }}
-                              items={LANGUAGES.map(({ value, label, country }) => ({
+                              items={LANGUAGES.map(({ value, label, labelKey, country }) => ({
                                 key: value,
-                                label,
+                                label: labelKey ? i18n.t(`settings:${labelKey}`) : label,
                                 leading: <LanguageFlag country={country} className="w-5 h-3.5" />,
-                                active: i18n.language === value || i18n.language.startsWith(value.split('-')[0]),
+                                active: draft.language === value,
                                 onClick: () => {
-                                  i18n.changeLanguage(value)
-                                  setDraft((prev) => ({ ...prev, language: value }))
-                                },
+                                  const language =
+                                    value === SYSTEM_LANGUAGE
+                                      ? getSystemLanguage()
+                                      : value
+
+                                  i18n.changeLanguage(language)
+
+                                setDraft((prev) => ({
+                                  ...prev,
+                                  language: value,
+                                }))
+                              },
                               }))}
                             />
                           </div>
@@ -897,16 +912,15 @@ export function OnboardingView({
                                 value={
                                   (() => {
                                     const lang = LANGUAGES.find(
-                                      (l) =>
-                                        draft.language === l.value ||
-                                        draft.language.startsWith(
-                                          l.value.split('-')[0],
-                                        ),
+                                      (l) => l.value === draft.language,
                                     )
+
                                     return lang ? (
                                       <span className="inline-flex items-center gap-1.5">
                                         <LanguageFlag country={lang.country} />
-                                        {lang.label}
+                                        {lang.labelKey
+                                          ? i18n.t(`settings:${lang.labelKey}`)
+                                          : lang.label}
                                       </span>
                                     ) : (
                                       draft.language


### PR DESCRIPTION
## Summary

This PR adds a new **System language** option to GodotHub's language selector and ordering.

My brother and I share the same computer, and we change the system language quite often. I prefer using the computer in Portuguese, while he prefers English.

Because of that, I decided to add a **System language** option so GodotHub can automatically follow the language currently configured in the operating system instead of requiring us to change the app language manually every time.

When selected, GodotHub now follows the language reported by the operating system while keeping **System language** as the selected preference instead of replacing it with the resolved locale.

For example, on a system configured as `pt-BR`:

- Selected preference: `system`
- Effective GodotHub language: `pt-BR`
- Selected option shown in the UI: **Idioma do sistema**

This allows GodotHub to follow the operating system language without losing the information that the user selected the automatic system-language option.

I initially wanted to sort the languages alphabetically, but that becomes ambiguous because each language has a different alphabetical order. I also considered translating every language name into the currently selected language and sorting based on those translated names.

I decided not to do that for now because I am still unsure whether that would be the best approach. Instead, I kept the ordering stable and predictable by sorting based on the English name of the country represented by each language's flag.

The language list now follows a consistent ordering rule:

- **System language** is always shown first.
- The remaining languages are grouped by translation status:
- Complete
- Beta
- Incomplete
- Within each status group, languages are sorted alphabetically by the English name of the country represented by their flag.
