### PR TITLE
Fix system language falling back to English on restart

### DIFF
--- a/src/components/reusables/LanguagePicker.tsx
+++ b/src/components/reusables/LanguagePicker.tsx
@@ -1,6 +1,7 @@
 import i18n from '../../i18n'
 import {
   LANGUAGES,
+  resolveLanguage,
   type LanguageStatus,
 } from '../../i18n/languages'
 import { IconCheck } from '../../lib/icons'
@@ -41,7 +42,7 @@ export function LanguagePicker({
     LANGUAGES.find((l) => isActive(l.value)) ?? LANGUAGES[0]
 
   const handleChange = (value: string) => {
-    i18n.changeLanguage(value)
+    i18n.changeLanguage(resolveLanguage(value))
     update({ ...settings, language: value })
   }
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -27,10 +27,7 @@ import {
   applyRadius,
   applyScrollbars,
 } from '../lib/appearance'
-import {
-  SYSTEM_LANGUAGE,
-  getSystemLanguage,
-} from '../i18n/languages'
+import { resolveLanguage } from '../i18n/languages'
 import { registerPendingSave } from '../lib/pendingSave'
 import { useWorkspaces } from './useWorkspaces'
 import { defaultCornerRadius } from '../lib/platform'
@@ -146,12 +143,11 @@ function applySettingsAppearance(prev: AppSettings, next: AppSettings) {
     applyProjectIconOpacity(next.project_icon_opacity)
   }
   if (next.language && next.language !== prev.language) {
-    localStorage.setItem('i18nextLng', next.language)
-    const resolvedLanguage = next.language === SYSTEM_LANGUAGE ? getSystemLanguage() : next.language
-
-if (resolvedLanguage !== i18n.language) {
-  i18n.changeLanguage(resolvedLanguage)
-}
+    const resolvedLanguage = resolveLanguage(next.language)
+    localStorage.setItem('i18nextLng', resolvedLanguage)
+    if (resolvedLanguage !== i18n.language) {
+      i18n.changeLanguage(resolvedLanguage)
+    }
   }
 }
 
@@ -181,12 +177,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         s.raised_contrast,
       )
       applyAppearance(s)
-      if (s.language && s.language !== i18n.language) {
-        i18n.changeLanguage(
-          s.language === SYSTEM_LANGUAGE
-          ? getSystemLanguage()
-           : s.language,
-          )
+      if (s.language) {
+        const resolvedLanguage = resolveLanguage(s.language)
+        if (resolvedLanguage !== i18n.language) {
+          i18n.changeLanguage(resolvedLanguage)
+        }
       }
       setLoaded(true)
     })
@@ -265,7 +260,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
             saved.raised_contrast,
           )
           if (saved.language) {
-            localStorage.setItem('i18nextLng', saved.language)
+            localStorage.setItem('i18nextLng', resolveLanguage(saved.language))
           }
           applyAppearance(saved)
         }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -2,6 +2,8 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 
+import { SYSTEM_LANGUAGE, getSystemLanguage } from './languages'
+
 import arMANav from './locales/ar-MA/nav.json'
 import arMACommon from './locales/ar-MA/common.json'
 import arMASettings from './locales/ar-MA/settings.json'
@@ -204,6 +206,18 @@ const resources = {
   ar: arMAResources,
   'vi-VN': viVNResources,
   vi: viVNResources,
+}
+
+// The language setting stores the literal 'system' choice, and earlier builds
+// cached that value as i18nextLng. It matches no resource bundle, so the
+// detector would resolve it to the en-US fallback on every launch. Rewrite it
+// to the actual system locale before the detector reads it.
+try {
+  if (localStorage.getItem('i18nextLng') === SYSTEM_LANGUAGE) {
+    localStorage.setItem('i18nextLng', getSystemLanguage())
+  }
+} catch {
+  // localStorage may be unavailable; the navigator detector still applies.
 }
 
 i18n

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -86,6 +86,11 @@ export function getSystemLanguage(): string {
   return 'en-US'
 }
 
+// Settings persist the literal 'system' choice; i18next needs a real locale.
+export function resolveLanguage(language: string): string {
+  return language === SYSTEM_LANGUAGE ? getSystemLanguage() : language
+}
+
 const STATUS_ORDER: Record<LanguageStatus, number> = {
   complete: 0,
   beta: 1,


### PR DESCRIPTION
Selecting **System language** applied the locale immediately but reverted to English after a restart.

## Why

The literal `system` was cached as `i18nextLng`, so on the next launch the detector picked a language with no resource bundle and resolved it to the `en-US` fallback. The startup check then compared the raw setting against `i18n.language` — also `system` — so `changeLanguage()` never ran.

The resolved locale is now what gets persisted, and an already-cached `system` value is rewritten before `init()` so existing installs recover without re-selecting the option.

`LanguagePicker` is currently unused but had the same `changeLanguage('system')` trap, so it is fixed alongside.