### PR TITLE
Fix repeated terminal launches when reopening GodotHub with Godot running

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "trash",
  "url",
  "uuid 1.23.4",
+ "windows-sys 0.61.2",
  "zip 8.6.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,3 +43,6 @@ tauri-plugin-single-instance = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod licenses;
 mod models;
 mod news;
 mod persist;
+mod process;
 mod projects;
 mod scan;
 mod settings;

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -1,0 +1,249 @@
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RunningProcess {
+    pub pid: u32,
+    pub project_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProcessLiveness {
+    Alive,
+    Exited,
+    Unknown,
+}
+
+pub(crate) fn parse_path_arg(cmdline: &str) -> Option<String> {
+    let start = cmdline
+        .match_indices("--path")
+        .find(|(index, _)| {
+            let before_ok = *index == 0
+                || cmdline[..*index]
+                    .chars()
+                    .last()
+                    .map(|c| c.is_ascii_whitespace())
+                    .unwrap_or(false);
+            let after = &cmdline[*index + "--path".len()..];
+            let after_ok = after
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_whitespace() || c == '=')
+                .unwrap_or(true);
+            before_ok && after_ok
+        })
+        .map(|(index, _)| index + "--path".len())?;
+
+    let rest = cmdline[start..]
+        .trim_start()
+        .strip_prefix('=')
+        .unwrap_or_else(|| cmdline[start..].trim_start());
+    if let Some(rest) = rest.strip_prefix('"') {
+        let end = rest.find('"')?;
+        let path = &rest[..end];
+        return (!path.is_empty()).then(|| path.to_string());
+    }
+    let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+    let path = &rest[..end];
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn parse_windows_process_output(output: &str) -> Vec<RunningProcess> {
+    let mut processes = output
+        .lines()
+        .filter_map(|line| {
+            let (pid, command_line) = line.split_once('\t')?;
+            let pid = pid.trim().parse().ok()?;
+            let project_path = parse_path_arg(command_line.trim())?;
+            Some(RunningProcess { pid, project_path })
+        })
+        .collect::<Vec<_>>();
+
+    let mut pid = None;
+    let mut command_line: Option<&str> = None;
+    for line in output.lines().map(str::trim) {
+        if let Some(value) = line.strip_prefix("ProcessId=") {
+            pid = value.trim().parse().ok();
+        } else if let Some(value) = line.strip_prefix("CommandLine=") {
+            command_line = Some(value.trim());
+        }
+        if let (Some(pid_value), Some(command_value)) = (pid, command_line) {
+            if let Some(project_path) = parse_path_arg(command_value) {
+                processes.push(RunningProcess {
+                    pid: pid_value,
+                    project_path,
+                });
+            }
+            pid = None;
+            command_line = None;
+        }
+    }
+
+    processes
+}
+
+#[cfg(unix)]
+fn parse_unix_process_output(output: &str) -> Vec<RunningProcess> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let (pid, command_line) = line.split_once(char::is_whitespace)?;
+            let pid = pid.trim().parse().ok()?;
+            if !command_line.to_ascii_lowercase().contains("godot") {
+                return None;
+            }
+            let project_path = parse_path_arg(command_line.trim())?;
+            Some(RunningProcess { pid, project_path })
+        })
+        .collect()
+}
+
+pub(crate) fn find_running_godot_processes() -> Result<Vec<RunningProcess>, String> {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const POWERSHELL_QUERY: &str = r#"
+$processes = if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
+    Get-CimInstance Win32_Process -Filter "Name LIKE 'Godot%'"
+} else {
+    Get-WmiObject Win32_Process -Filter "Name LIKE 'Godot%'"
+}
+$processes | Where-Object { $_.CommandLine } | ForEach-Object {
+    "{0}`t{1}" -f $_.ProcessId, $_.CommandLine
+}
+"#;
+
+        let powershell = Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                POWERSHELL_QUERY,
+            ])
+            .creation_flags(crate::terminal::CREATE_NO_WINDOW)
+            .output();
+
+        return match powershell {
+            Ok(output) if output.status.success() => Ok(parse_windows_process_output(
+                &String::from_utf8_lossy(&output.stdout),
+            )),
+            _ => {
+                let output = Command::new("wmic")
+                    .args([
+                        "process",
+                        "where",
+                        "name like 'Godot%'",
+                        "get",
+                        "processid,commandline",
+                        "/format:list",
+                    ])
+                    .creation_flags(crate::terminal::CREATE_NO_WINDOW)
+                    .output()
+                    .map_err(|e| e.to_string())?;
+                if !output.status.success() {
+                    return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+                }
+                Ok(parse_windows_process_output(&String::from_utf8_lossy(
+                    &output.stdout,
+                )))
+            }
+        };
+    }
+
+    #[cfg(unix)]
+    {
+        let output = Command::new("ps")
+            .args(["-eo", "pid=,args="])
+            .output()
+            .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+        }
+        Ok(parse_unix_process_output(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    }
+}
+
+pub(crate) fn process_liveness(pid: u32) -> ProcessLiveness {
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            return ProcessLiveness::Unknown;
+        }
+        let mut exit_code = 0u32;
+        let queried = unsafe { GetExitCodeProcess(handle, &mut exit_code) != 0 };
+        unsafe { CloseHandle(handle) };
+        if !queried {
+            ProcessLiveness::Unknown
+        } else if exit_code == 259 {
+            ProcessLiveness::Alive
+        } else {
+            ProcessLiveness::Exited
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if result == 0 {
+            return ProcessLiveness::Alive;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(code) if code == libc::ESRCH => ProcessLiveness::Exited,
+            _ => ProcessLiveness::Unknown,
+        }
+    }
+}
+
+pub(crate) fn terminate_process(pid: u32) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, TerminateProcess, PROCESS_TERMINATE,
+        };
+
+        let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+        if handle.is_null() {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let result = unsafe { TerminateProcess(handle, 1) };
+        unsafe { CloseHandle(handle) };
+        if result == 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        if unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) } == 0 {
+            return Ok(());
+        }
+        Err(std::io::Error::last_os_error().to_string())
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/common/process.rs"]
+mod process_common_tests;
+
+#[cfg(target_os = "windows")]
+#[cfg(test)]
+#[path = "../tests/windows/process.rs"]
+mod windows_process_tests;
+
+#[cfg(unix)]
+#[cfg(test)]
+#[path = "../tests/unix/process.rs"]
+mod unix_process_tests;

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -1,5 +1,6 @@
 use crate::models::*;
 use crate::persist;
+use crate::process::{self, ProcessLiveness};
 use crate::settings;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -15,26 +16,40 @@ use std::time::SystemTime;
 
 pub enum TrackedHandle {
     Child(Child),
-    #[cfg(unix)]
-    Pid(u32),
-    PollAlive { project_path: String },
+    Pid { pid: u32, project_path: String },
 }
 
 pub struct TrackedProcess {
     pub handle: TrackedHandle,
     pub kill_tree: bool,
     pub launched_at: std::time::SystemTime,
+    pid_revalidated: bool,
 }
 
 impl TrackedProcess {
     fn is_running(&mut self) -> bool {
         match &mut self.handle {
             TrackedHandle::Child(child) => matches!(child.try_wait(), Ok(None)),
-            #[cfg(unix)]
-            TrackedHandle::Pid(pid) => crate::terminal::process_is_alive(*pid),
-            TrackedHandle::PollAlive { project_path } => {
-                let running = find_running_godot_project_paths();
-                running.iter().any(|p| same_path(p, project_path))
+            TrackedHandle::Pid { pid, project_path } => {
+                match process::process_liveness(*pid) {
+                    ProcessLiveness::Alive => true,
+                    ProcessLiveness::Exited => {
+                        if self.pid_revalidated {
+                            return false;
+                        }
+                        self.pid_revalidated = true;
+                        match process::find_running_godot_processes() {
+                            Ok(processes) => processes.iter().any(|running| {
+                                running.pid == *pid
+                                    && same_path(&running.project_path, project_path)
+                            }),
+                            Err(_) => true,
+                        }
+                    }
+                    // A permission error is not evidence that the process exited. Keep
+                    // monitoring it; the next poll may succeed after a transient error.
+                    ProcessLiveness::Unknown => true,
+                }
             }
         }
     }
@@ -135,63 +150,6 @@ fn settle_project_session(
     }
 }
 
-fn parse_path_arg(cmdline: &str) -> Option<String> {
-    let args: Vec<&str> = cmdline.split_whitespace().collect();
-    for (i, arg) in args.iter().enumerate() {
-        if *arg == "--path" {
-            if let Some(next) = args.get(i + 1) {
-                let p = next.trim_start_matches('"').trim_end_matches('"');
-                if !p.is_empty() {
-                    return Some(p.to_string());
-                }
-            }
-        }
-    }
-    None
-}
-
-fn find_running_godot_project_paths() -> std::collections::HashSet<String> {
-    let mut paths = std::collections::HashSet::new();
-    let output = gather_godot_process_lines();
-    for line in output.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Some(project_path) = parse_path_arg(trimmed) {
-            paths.insert(project_path);
-        }
-    }
-    paths
-}
-
-#[cfg(target_os = "windows")]
-fn gather_godot_process_lines() -> String {
-    use std::process::Command;
-    Command::new("wmic")
-        .args(["process", "where", "name like 'Godot%'", "get", "commandline"])
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default()
-}
-
-#[cfg(unix)]
-fn gather_godot_process_lines() -> String {
-    use std::process::Command;
-    let raw = Command::new("ps")
-        .args(["-eo", "args"])
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default();
-    raw.lines()
-        .filter(|l| {
-            let lower = l.to_lowercase();
-            lower.contains("godot") && lower.contains("--path")
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 pub(crate) fn settle_stale_sessions(app: &AppHandle) {
     static SETTLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     SETTLED.get_or_init(|| {
@@ -204,13 +162,27 @@ pub(crate) fn settle_stale_sessions(app: &AppHandle) {
         };
         let projects = read_projects(app);
 
-        let os_running = find_running_godot_project_paths();
+        let Ok(os_running) = process::find_running_godot_processes() else {
+            // Process discovery is required to distinguish an exited session from a
+            // temporarily unavailable process listing. Leave the session untouched and
+            // let the next application start retry discovery.
+            return;
+        };
 
         for p in projects {
             if p.session_started_at_ms.is_some() && !running.contains(&p.id) {
-                let still_running = os_running.iter().any(|os_path| same_path(os_path, &p.path));
-                if still_running {
-                    retrack_stale_session(app, &p);
+                if let Some(running_process) = os_running
+                    .iter()
+                    .find(|process| same_path(&process.project_path, &p.path))
+                {
+                    retrack_stale_session(
+                        app,
+                        &p,
+                        TrackedHandle::Pid {
+                            pid: running_process.pid,
+                            project_path: p.path.clone(),
+                        },
+                    );
                 } else {
                     settle_project_session(app, &p.id, None);
                 }
@@ -219,18 +191,18 @@ pub(crate) fn settle_stale_sessions(app: &AppHandle) {
     });
 }
 
-fn retrack_stale_session(app: &AppHandle, project: &Project) {
+fn retrack_stale_session(app: &AppHandle, project: &Project, handle: TrackedHandle) {
     let Some(state) = app.try_state::<ActiveProcesses>() else {
         return;
     };
 
     let id = project.id.clone();
-    let path = project.path.clone();
     let app_clone = app.clone();
 
     let tracked = TrackedProcess {
-        handle: TrackedHandle::PollAlive { project_path: path },
+        handle,
         kill_tree: false,
+        pid_revalidated: false,
         launched_at: std::time::UNIX_EPOCH
             + std::time::Duration::from_millis(
                 project
@@ -894,6 +866,7 @@ pub fn open_project(
             TrackedProcess {
                 handle: TrackedHandle::Child(launched.child),
                 kill_tree,
+                pid_revalidated: false,
                 launched_at: std::time::SystemTime::now(),
             },
         );
@@ -962,7 +935,19 @@ fn adopt_terminal_pid(app: &AppHandle, id: &str, pid_file: &Path) {
                 let mut active = state.0.lock().unwrap();
                 active
                     .get_mut(id)
-                    .map(|tracked| std::mem::replace(&mut tracked.handle, TrackedHandle::Pid(pid)))
+                    .map(|tracked| {
+                        std::mem::replace(
+                            &mut tracked.handle,
+                            TrackedHandle::Pid {
+                                pid,
+                                project_path: read_projects(app)
+                                    .into_iter()
+                                    .find(|project| project.id == id)
+                                    .map(|project| project.path)
+                                    .unwrap_or_default(),
+                            },
+                        )
+                    })
             };
 
             if let Some(TrackedHandle::Child(mut launcher)) = replaced {
@@ -976,25 +961,22 @@ fn adopt_terminal_pid(app: &AppHandle, id: &str, pid_file: &Path) {
 
 fn wait_until_exited(app: &AppHandle, id: &str) {
     const POLL: std::time::Duration = std::time::Duration::from_millis(500);
-    const POLL_SLOW: std::time::Duration = std::time::Duration::from_secs(5);
-
     loop {
         let Some(state) = app.try_state::<ActiveProcesses>() else {
             return;
         };
 
-        let (exited, is_poll) = {
+        let exited = {
             let mut active = state.0.lock().unwrap();
             let Some(tracked) = active.get_mut(id) else {
                 return;
             };
-            let is_poll = matches!(tracked.handle, TrackedHandle::PollAlive { .. });
             if tracked.is_running() {
-                (None, is_poll)
+                None
             } else {
                 let elapsed = tracked.launched_at.elapsed().ok();
                 active.remove(id);
-                (Some(elapsed), is_poll)
+                Some(elapsed)
             }
         };
 
@@ -1004,7 +986,7 @@ fn wait_until_exited(app: &AppHandle, id: &str) {
             return;
         }
 
-        std::thread::sleep(if is_poll { POLL_SLOW } else { POLL });
+        std::thread::sleep(POLL);
     }
 }
 
@@ -1031,10 +1013,15 @@ fn kill_tracked(tracked: &mut TrackedProcess) -> Result<(), String> {
             child.wait().ok();
             Ok(())
         }
-        #[cfg(unix)]
-        TrackedHandle::Pid(pid) => crate::terminal::terminate_process(*pid),
-        TrackedHandle::PollAlive { .. } => {
-            Ok(())
+        TrackedHandle::Pid { pid, project_path } => {
+            let processes = process::find_running_godot_processes()
+                .map_err(|error| format!("Could not verify Godot process identity: {error}"))?;
+            if !processes.iter().any(|running| {
+                running.pid == *pid && same_path(&running.project_path, project_path)
+            }) {
+                return Err("Refusing to terminate a PID whose Godot identity no longer matches".into());
+            }
+            process::terminate_process(*pid)
         }
     }
 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -236,19 +236,6 @@ pub fn read_pid_file(path: &Path) -> Option<u32> {
         .filter(|pid| *pid > 1)
 }
 
-#[cfg(unix)]
-pub fn process_is_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(unix)]
-pub fn terminate_process(pid: u32) -> Result<(), String> {
-    if unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) } == 0 {
-        return Ok(());
-    }
-    Err(std::io::Error::last_os_error().to_string())
-}
-
 #[cfg(target_os = "windows")]
 fn console_title(raw: &str) -> String {
     let cleaned: String = raw

--- a/src-tauri/tests/common/process.rs
+++ b/src-tauri/tests/common/process.rs
@@ -1,0 +1,30 @@
+use super::parse_path_arg;
+
+#[test]
+fn parses_quoted_project_path() {
+    assert_eq!(
+        parse_path_arg(r#"Godot_v4.exe --path "D:\Game Projects\Demo" --editor"#),
+        Some(r#"D:\Game Projects\Demo"#.to_string())
+    );
+}
+
+#[test]
+fn parses_unquoted_project_path() {
+    assert_eq!(
+        parse_path_arg(r#"Godot_v4.exe --path D:\Demo --editor"#),
+        Some(r#"D:\Demo"#.to_string())
+    );
+}
+
+#[test]
+fn parses_equals_project_path() {
+    assert_eq!(
+        parse_path_arg(r#"Godot_v4.exe --path="D:\Game Projects\Demo" --editor"#),
+        Some(r#"D:\Game Projects\Demo"#.to_string())
+    );
+}
+
+#[test]
+fn ignores_path_like_argument_names() {
+    assert_eq!(parse_path_arg("Godot_v4.exe --pathology D:\\Nope"), None);
+}

--- a/src-tauri/tests/unix/process.rs
+++ b/src-tauri/tests/unix/process.rs
@@ -1,0 +1,43 @@
+use super::{parse_unix_process_output, RunningProcess};
+
+#[test]
+fn parses_ps_output() {
+    assert_eq!(
+        parse_unix_process_output("1234 Godot_v4 --path /tmp/game --editor\n"),
+        vec![RunningProcess {
+            pid: 1234,
+            project_path: "/tmp/game".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn parses_multiple_processes_and_skips_unrelated_commands() {
+    let processes = parse_unix_process_output(
+        "101 launchd\n202 Godot --path /Users/test/one --editor\n303 godot-mono --path=/Users/test/two\n",
+    );
+    assert_eq!(
+        processes,
+        vec![
+            RunningProcess {
+                pid: 202,
+                project_path: "/Users/test/one".to_string(),
+            },
+            RunningProcess {
+                pid: 303,
+                project_path: "/Users/test/two".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn parses_quoted_paths() {
+    assert_eq!(
+        parse_unix_process_output("404 Godot --path \"/Users/test/game with spaces\" --editor\n"),
+        vec![RunningProcess {
+            pid: 404,
+            project_path: "/Users/test/game with spaces".to_string(),
+        }]
+    );
+}

--- a/src-tauri/tests/windows/process.rs
+++ b/src-tauri/tests/windows/process.rs
@@ -1,0 +1,37 @@
+use super::{parse_windows_process_output, RunningProcess};
+
+#[test]
+fn parses_tab_output() {
+    assert_eq!(
+        parse_windows_process_output(
+            "1234\tGodot_v4.exe --path \"D:\\Game Projects\\Demo\" --editor\r\n"
+        ),
+        vec![RunningProcess {
+            pid: 1234,
+            project_path: "D:\\Game Projects\\Demo".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn parses_wmic_list_output_in_either_order() {
+    let processes = parse_windows_process_output(
+        "CommandLine=Godot_v4.exe --path=\"D:\\Demo\"\r\nProcessId=4321\r\n\r\n",
+    );
+    assert_eq!(processes[0].pid, 4321);
+    assert_eq!(processes[0].project_path, "D:\\Demo");
+}
+
+#[test]
+fn skips_malformed_wmic_records() {
+    let processes = parse_windows_process_output(
+        "CommandLine=Godot --path D:\\Valid\r\nProcessId=700\r\n\r\nProcessId=not-a-pid\r\nCommandLine=Godot --path D:\\Ignored\r\n",
+    );
+    assert_eq!(
+        processes,
+        vec![RunningProcess {
+            pid: 700,
+            project_path: "D:\\Valid".to_string(),
+        }]
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a Windows issue where reopening GodotHub while a Godot project was
still running could cause a terminal window to repeatedly open and close.

The same session-tracking behavior is now unified across Windows and Unix
platforms, including Linux and macOS.

## Problem

The issue could be reproduced as follows:

1. Start GodotHub.
2. Open a Godot project.
3. Enable `Close application on project open`, or close GodotHub manually.
4. Leave the Godot project running.
5. Start GodotHub again.

Under the affected implementation, GodotHub recovered the stale project session
using platform-specific process detection. The monitoring path could repeatedly
launch external process-query commands such as PowerShell, WMIC, or `ps`.

On Windows, these helper-process launches could become visible as terminal
windows, producing this loop:

```text
terminal starts
→ terminal closes immediately
→ terminal starts again
→ terminal closes immediately
→ repeat
```

Closing the Godot process stopped the loop because the stale-session monitor no
longer had an active process to track.

## Root Cause

Process discovery and process monitoring were mixed together:

- Unix used path-based polling.
- Windows used PID checks together with external process discovery.
- Recovered sessions did not share one platform-neutral process-tracking model.
- External process-query commands could be invoked repeatedly during monitoring.

## Solution
This PR introduces a dedicated cross-platform process module.

### Process tracking

- Process discovery is performed once during stale-session recovery.
- Recovered sessions are tracked by PID on both Windows and Unix.
- Normal monitoring uses direct PID liveness checks.
- Windows uses `OpenProcess` and `GetExitCodeProcess`.
- Unix uses `kill(pid, 0)`.
- If a PID appears to have exited, the process identity is revalidated once
  against the stored Godot project path.
- Process termination verifies the PID/project identity before killing it.

### Test organization

Process tests were moved out of projects.rs and organized as:

```text
src-tauri/tests/
├── common/process.rs
├── windows/process.rs
└── unix/process.rs
```

## Expected Result

- Reopening GodotHub while Godot is still running no longer starts a repeated
  terminal open/close loop.
- The normal process-monitoring loop does not repeatedly launch PowerShell,
  WMIC, or `ps`.
- Windows, Linux, and macOS use the same PID-based session lifecycle.
- Existing project launch, close, stale-session recovery, and time tracking
  behavior remains unchanged.

## Verification

Passed locally:

- cargo test --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-msvc
- bun run lint
- bunx tsc --noEmit

The Windows-specific tests run on the current Windows environment. The Unix
tests are selected with `cfg(unix)` and should be run on Linux/macOS CI or
native development environments.

## Files Changed

- src-tauri/src/process.rs
- src-tauri/src/projects.rs
- src-tauri/src/terminal.rs
- src-tauri/src/lib.rs
- src-tauri/Cargo.toml
- src-tauri/Cargo.lock
- src-tauri/tests/common/process.rs
- src-tauri/tests/windows/process.rs
- src-tauri/tests/unix/process.rs